### PR TITLE
Support Blocking Effects

### DIFF
--- a/src/main/scala/akka/http/interop/ZIOSupport.scala
+++ b/src/main/scala/akka/http/interop/ZIOSupport.scala
@@ -4,7 +4,8 @@ import akka.http.scaladsl.marshalling.{ Marshaller, Marshalling, PredefinedToRes
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.server.{ RequestContext, Route, RouteResult }
-import zio.{ BootstrapRuntime, IO, UIO }
+import zio.{ BootstrapRuntime, ZIO, IO, UIO }
+import zio.blocking.Blocking
 
 import scala.concurrent.{ Future, Promise }
 import scala.language.implicitConversions
@@ -38,7 +39,7 @@ trait ZIOSupportInstances2 extends BootstrapRuntime {
   implicit def zioSupportIOMarshaller[A, E](
     implicit ma: Marshaller[A, HttpResponse],
     me: Marshaller[E, HttpResponse]
-  ): Marshaller[IO[E, A], HttpResponse] =
+  ): Marshaller[ZIO[Blocking, E, A], HttpResponse] =
     Marshaller { implicit ec => a =>
       val r = a.foldM(
         e => IO.fromFuture(implicit ec => me(e)),

--- a/src/test/scala/akka/http/interop/Api.scala
+++ b/src/test/scala/akka/http/interop/Api.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import zio.{ IO, ZIO }
+import zio.blocking._
 
 object Api extends ZIOSupport {
 
@@ -28,10 +29,16 @@ object Api extends ZIOSupport {
         complete(res)
       }
     } ~
-      pathPrefix("bad_request") {
-        get {
-          val res: IO[DomainError, String] = ZIO.fail(BadData)
-          complete(res)
-        }
+    pathPrefix("bad_request") {
+      get {
+        val res: IO[DomainError, String] = ZIO.fail(BadData)
+        complete(res)
       }
+    } ~
+    pathPrefix("blocking_request") {
+      get {
+        val res: ZIO[Blocking, DomainError, String] = blocking(ZIO.succeed("OK"))
+        complete(res)
+      }
+    }
 }

--- a/src/test/scala/akka/http/interop/ZIOInteropSpec.scala
+++ b/src/test/scala/akka/http/interop/ZIOInteropSpec.scala
@@ -58,6 +58,12 @@ object ZIOInteropSpec extends ZIORouteTest {
           val s = status
           assert(s)(equalTo(StatusCodes.OK))
         })
+      },
+      testM("succeed on /blocking_request (no domain errors)") {
+        ZIO.effect(Get("/blocking_request") ~> domainRoutes ~> check {
+          val s = status
+          assert(s)(equalTo(StatusCodes.OK))
+        })
       }
     )
 


### PR DESCRIPTION
If your route contains any blocking code, the IO Marshaller won't supply the Blocking environment. This fixes that ... your route can now contain blocking code (if it has to :) ).