### PR TITLE
bumped ZIO to 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import ReleaseTransformations._
 import ReleasePlugin.autoImport._
 
-val zioVersion      = "1.0.0-RC19"
-val akkaVersion     = "2.6.5"
+val zioVersion      = "1.0.0"
+val akkaVersion     = "2.6.8"
 val akkaHttpVersion = "10.1.12"
 
 val compilerOptions = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.13


### PR DESCRIPTION
@vpavkin Hi!

I want to update `zio-akka-quickstart.g8` to 1.0.0 and first need to bump it in interop libs.