### PR TITLE
Make ErrorResponse contravariant

### DIFF
--- a/src/main/scala/akka/http/interop/ErrorResponse.scala
+++ b/src/main/scala/akka/http/interop/ErrorResponse.scala
@@ -5,6 +5,6 @@ import akka.http.scaladsl.model.HttpResponse
 /**
  * Describes how to map a custom domain error into an HTTP server response
  */
-trait ErrorResponse[E] {
+trait ErrorResponse[-E] {
   def toHttpResponse(e: E): HttpResponse
 }

--- a/src/test/scala/akka/http/interop/Api.scala
+++ b/src/test/scala/akka/http/interop/Api.scala
@@ -33,5 +33,11 @@ object Api extends ZIOSupport {
           val res: IO[DomainError, String] = ZIO.fail(BadData)
           complete(res)
         }
+      } ~
+      pathPrefix("bad_request_narrow") {
+        get {
+          val res: IO[BadData.type, String] = ZIO.fail(BadData)
+          complete(res)
+        }
       }
 }

--- a/src/test/scala/akka/http/interop/ZIOInteropSpec.scala
+++ b/src/test/scala/akka/http/interop/ZIOInteropSpec.scala
@@ -46,8 +46,8 @@ object ZIOInteropSpec extends ZIORouteTest {
           assert(s)(equalTo(StatusCodes.BadRequest))
         })
       },
-      testM("fail with 400 on /bad_request_narrow") {
-        ZIO.effect(Get("/bad_request_narrow") ~> domainRoutes ~> check {
+      test("fail with 400 on /bad_request_narrow") {
+        ZIO.attempt(Get("/bad_request_narrow") ~> domainRoutes ~> check {
           val s = status
           assert(s)(equalTo(StatusCodes.BadRequest))
         })

--- a/src/test/scala/akka/http/interop/ZIOInteropSpec.scala
+++ b/src/test/scala/akka/http/interop/ZIOInteropSpec.scala
@@ -47,6 +47,12 @@ object ZIOInteropSpec extends ZIORouteTest {
           assert(s)(equalTo(StatusCodes.BadRequest))
         })
       },
+      testM("fail with 400 on /bad_request_narrow") {
+        ZIO.effect(Get("/bad_request_narrow") ~> domainRoutes ~> check {
+          val s = status
+          assert(s)(equalTo(StatusCodes.BadRequest))
+        })
+      },
       testM("succeed fail with 500 on /task (no domain errors)") {
         ZIO.effect(Get("/task") ~> simpleRoutes ~> check {
           val s = status


### PR DESCRIPTION
Consider the following code

```scala
object Api extends ZIOSupport {

  sealed trait DomainError
  case object Internal extends DomainError
  case object NotFound extends DomainError

  trait Service {
    def find(id: String): IO[DomainError, String]     = UIO(id)
    def upsert(id: String): IO[Internal.type, String] = UIO(id)
  }

  implicit val domainErrorResponse: ErrorResponse[DomainError] = {
    case Internal => HttpResponse(StatusCodes.InternalServerError)
    case NotFound => HttpResponse(StatusCodes.NotFound)
  }

  val live: Service = new Service {}

  val routes: Route =
    get {
      complete(live.find("something"))
    } ~ post {
      complete(live.upsert("something"))
    }
}
```

I would expect it to compile because if `ErrorResponse` can handle `DomainError` then it should definitely be able to handle any subtype of `DomainError`. Basically `ErrorResponse` is a `T => HttpResponse` function and functions are contravariant on their parameters.
This PR makes a really small change by making ErrorResponse contravariant on `T`.